### PR TITLE
Handle Wikipedia Category renaming

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -25,7 +25,6 @@ require 'wikidata/fetcher'
 ]
 
 no_names = @pages.map { |c| WikiData::Category.new(c, 'no').member_titles }.flatten.uniq
-en_names = WikiData::Category.new('Category:Members of the Parliament of Norway', 'en').member_titles
+en_names = WikiData::Category.new('Category:Members of the Storting', 'en').member_titles
 
 EveryPolitician::Wikidata.scrape_wikidata(names: { no: no_names, en: en_names }, batch_size: 50, output: false)
-


### PR DESCRIPTION
Changed Wikipedia category name that was source for en_names as category name had changed.

Also, the scraper was scraping list names in addition to member names and treating them as member names. Amended scraper to remove list names.

closes https://github.com/everypolitician/everypolitician-data/issues/15338
